### PR TITLE
Fixes #28089 - capsule upgrade support

### DIFF
--- a/definitions/checks/original_assets.rb
+++ b/definitions/checks/original_assets.rb
@@ -2,6 +2,7 @@ class Checks::OriginalAssets < ForemanMaintain::Check
   metadata do
     description 'Check if only installed assets are present on the system'
     tags :post_upgrade
+    for_feature :foreman_server
   end
 
   ASSETS_DIR = '/var/lib/foreman/public/assets'.freeze

--- a/definitions/scenarios/upgrade_to_capsule_6_7.rb
+++ b/definitions/scenarios/upgrade_to_capsule_6_7.rb
@@ -1,10 +1,10 @@
-module Scenarios::Satellite_6_5
+module Scenarios::Capsule_6_7
   class Abstract < ForemanMaintain::Scenario
     def self.upgrade_metadata(&block)
       metadata do
-        tags :upgrade_to_satellite_6_5
+        tags :upgrade_to_capsule_6_7
         confine do
-          feature(:satellite) && feature(:satellite).current_minor_version == '6.4'
+          feature(:capsule) && feature(:capsule).current_minor_version == '6.6'
         end
         instance_eval(&block)
       end
@@ -13,7 +13,7 @@ module Scenarios::Satellite_6_5
 
   class PreUpgradeCheck < Abstract
     upgrade_metadata do
-      description 'Checks before upgrading to Satellite 6.5'
+      description 'Checks before upgrading to Capsule 6.7'
       tags :pre_upgrade_checks
       run_strategy :fail_slow
     end
@@ -21,13 +21,14 @@ module Scenarios::Satellite_6_5
     def compose
       add_steps(find_checks(:default))
       add_steps(find_checks(:pre_upgrade))
-      add_step(Checks::Repositories::Validate.new(:version => '6.5'))
+      add_step(Checks::RemoteExecution::VerifySettingsFileAlreadyExists.new)
+      add_step(Checks::Repositories::Validate.new(:version => '6.7'))
     end
   end
 
   class PreMigrations < Abstract
     upgrade_metadata do
-      description 'Procedures before migrating to Satellite 6.5'
+      description 'Procedures before migrating to Capsule 6.7'
       tags :pre_migrations
     end
 
@@ -39,12 +40,12 @@ module Scenarios::Satellite_6_5
 
   class Migrations < Abstract
     upgrade_metadata do
-      description 'Migration scripts to Satellite 6.5'
+      description 'Migration scripts to Capsule 6.7'
       tags :migrations
     end
 
     def compose
-      add_step(Procedures::Repositories::Setup.new(:version => '6.5'))
+      add_step(Procedures::Repositories::Setup.new(:version => '6.7'))
       add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
       add_step(Procedures::Installer::Upgrade.new)
@@ -53,7 +54,7 @@ module Scenarios::Satellite_6_5
 
   class PostMigrations < Abstract
     upgrade_metadata do
-      description 'Procedures after migrating to Satellite 6.5'
+      description 'Procedures after migrating to Capsule 6.7'
       tags :post_migrations
     end
 
@@ -65,7 +66,7 @@ module Scenarios::Satellite_6_5
 
   class PostUpgradeChecks < Abstract
     upgrade_metadata do
-      description 'Checks after upgrading to Satellite 6.5'
+      description 'Checks after upgrading to Capsule 6.7'
       tags :post_upgrade_checks
       run_strategy :fail_slow
     end

--- a/definitions/scenarios/upgrade_to_capsule_6_7_z.rb
+++ b/definitions/scenarios/upgrade_to_capsule_6_7_z.rb
@@ -1,10 +1,10 @@
-module Scenarios::Satellite_6_5
+module Scenarios::Capsule_6_7_z
   class Abstract < ForemanMaintain::Scenario
     def self.upgrade_metadata(&block)
       metadata do
-        tags :upgrade_to_satellite_6_5
+        tags :upgrade_to_capsule_6_7_z
         confine do
-          feature(:satellite) && feature(:satellite).current_minor_version == '6.4'
+          feature(:capsule) && feature(:capsule).current_minor_version == '6.7'
         end
         instance_eval(&block)
       end
@@ -13,7 +13,7 @@ module Scenarios::Satellite_6_5
 
   class PreUpgradeCheck < Abstract
     upgrade_metadata do
-      description 'Checks before upgrading to Satellite 6.5'
+      description 'Checks before upgrading to Capsule 6.7.z'
       tags :pre_upgrade_checks
       run_strategy :fail_slow
     end
@@ -21,13 +21,14 @@ module Scenarios::Satellite_6_5
     def compose
       add_steps(find_checks(:default))
       add_steps(find_checks(:pre_upgrade))
-      add_step(Checks::Repositories::Validate.new(:version => '6.5'))
+      add_step(Checks::RemoteExecution::VerifySettingsFileAlreadyExists.new)
+      add_step(Checks::Repositories::Validate.new(:version => '6.7'))
     end
   end
 
   class PreMigrations < Abstract
     upgrade_metadata do
-      description 'Procedures before migrating to Satellite 6.5'
+      description 'Procedures before migrating to Capsule 6.7.z'
       tags :pre_migrations
     end
 
@@ -39,12 +40,12 @@ module Scenarios::Satellite_6_5
 
   class Migrations < Abstract
     upgrade_metadata do
-      description 'Migration scripts to Satellite 6.5'
+      description 'Migration scripts to Capsule 6.7.z'
       tags :migrations
     end
 
     def compose
-      add_step(Procedures::Repositories::Setup.new(:version => '6.5'))
+      add_step(Procedures::Repositories::Setup.new(:version => '6.7'))
       add_step(Procedures::Packages::UnlockVersions.new)
       add_step(Procedures::Packages::Update.new(:assumeyes => true))
       add_step(Procedures::Installer::Upgrade.new)
@@ -53,7 +54,7 @@ module Scenarios::Satellite_6_5
 
   class PostMigrations < Abstract
     upgrade_metadata do
-      description 'Procedures after migrating to Satellite 6.5'
+      description 'Procedures after migrating to Capsule 6.7.z'
       tags :post_migrations
     end
 
@@ -65,7 +66,7 @@ module Scenarios::Satellite_6_5
 
   class PostUpgradeChecks < Abstract
     upgrade_metadata do
-      description 'Checks after upgrading to Satellite 6.5'
+      description 'Checks after upgrading to Capsule 6.7.z'
       tags :post_upgrade_checks
       run_strategy :fail_slow
     end

--- a/definitions/scenarios/upgrade_to_satellite_6_2.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_2.rb
@@ -76,5 +76,3 @@ module Scenarios::Satellite_6_2
     end
   end
 end
-
-ForemanMaintain::UpgradeRunner.register_version('6.2', :upgrade_to_satellite_6_2)

--- a/definitions/scenarios/upgrade_to_satellite_6_2_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_2_z.rb
@@ -76,5 +76,3 @@ module Scenarios::Satellite_6_2_z
     end
   end
 end
-
-ForemanMaintain::UpgradeRunner.register_version('6.2.z', :upgrade_to_satellite_6_2_z)

--- a/definitions/scenarios/upgrade_to_satellite_6_3.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_3.rb
@@ -77,5 +77,3 @@ module Scenarios::Satellite_6_3
     end
   end
 end
-
-ForemanMaintain::UpgradeRunner.register_version('6.3', :upgrade_to_satellite_6_3)

--- a/definitions/scenarios/upgrade_to_satellite_6_3_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_3_z.rb
@@ -76,5 +76,3 @@ module Scenarios::Satellite_6_3_z
     end
   end
 end
-
-ForemanMaintain::UpgradeRunner.register_version('6.3.z', :upgrade_to_satellite_6_3_z)

--- a/definitions/scenarios/upgrade_to_satellite_6_4.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_4.rb
@@ -77,5 +77,3 @@ module Scenarios::Satellite_6_4
     end
   end
 end
-
-ForemanMaintain::UpgradeRunner.register_version('6.4', :upgrade_to_satellite_6_4)

--- a/definitions/scenarios/upgrade_to_satellite_6_4_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_4_z.rb
@@ -77,4 +77,3 @@ module Scenarios::Satellite_6_4_z
   end
 end
 
-ForemanMaintain::UpgradeRunner.register_version('6.4.z', :upgrade_to_satellite_6_4_z)

--- a/definitions/scenarios/upgrade_to_satellite_6_5_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_5_z.rb
@@ -76,5 +76,3 @@ module Scenarios::Satellite_6_5_z
     end
   end
 end
-
-ForemanMaintain::UpgradeRunner.register_version('6.5.z', :upgrade_to_satellite_6_5_z)

--- a/definitions/scenarios/upgrade_to_satellite_6_6.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_6.rb
@@ -78,5 +78,3 @@ module Scenarios::Satellite_6_6
     end
   end
 end
-
-ForemanMaintain::UpgradeRunner.register_version('6.6', :upgrade_to_satellite_6_6)

--- a/definitions/scenarios/upgrade_to_satellite_6_6_z.rb
+++ b/definitions/scenarios/upgrade_to_satellite_6_6_z.rb
@@ -78,5 +78,3 @@ module Scenarios::Satellite_6_6_z
     end
   end
 end
-
-ForemanMaintain::UpgradeRunner.register_version('6.6.z', :upgrade_to_satellite_6_6_z)

--- a/definitions/scenarios/versions_tags_mappings.rb
+++ b/definitions/scenarios/versions_tags_mappings.rb
@@ -1,0 +1,41 @@
+SATELLITE_MAPPINGS = { '6.2' => :upgrade_to_satellite_6_2,
+                       '6.2.z' => :upgrade_to_satellite_6_2_z,
+                       '6.3' => :upgrade_to_satellite_6_3,
+                       '6.3.z' => :upgrade_to_satellite_6_3_z,
+                       '6.4' => :upgrade_to_satellite_6_4,
+                       '6.4.z' => :upgrade_to_satellite_6_4_z,
+                       '6.5' => :upgrade_to_satellite_6_5,
+                       '6.5.z' => :upgrade_to_satellite_6_5_z,
+                       '6.6' => :upgrade_to_satellite_6_6,
+                       '6.6.z' => :upgrade_to_satellite_6_6_z }.freeze
+
+CAPSULE_MAPPINGS = {
+  '6.7' => :upgrade_to_capsule_6_7,
+  '6.7.z' => :upgrade_to_capsule_6_7_z
+}.freeze
+
+def pkg_manager
+  ForemanMaintain::PackageManager::Yum.new
+end
+
+def satellite?
+  pkg_manager.installed?('satellite')
+end
+
+def capsule?
+  pkg_manager.installed?('satellite-capsule')
+end
+
+def call_register_version(version, tag)
+  ForemanMaintain::UpgradeRunner.register_version(version, tag)
+end
+
+if satellite?
+  SATELLITE_MAPPINGS.each do |version, tag|
+    call_register_version(version, tag)
+  end
+elsif capsule?
+  CAPSULE_MAPPINGS.each do |version, tag|
+    call_register_version(version, tag)
+  end
+end

--- a/lib/foreman_maintain/concerns/downstream.rb
+++ b/lib/foreman_maintain/concerns/downstream.rb
@@ -98,16 +98,21 @@ module ForemanMaintain
       end
 
       def common_repos(rh_version_major, full_version)
-        tools_repo_id = "rhel-#{rh_version_major}-server-satellite-tools-#{full_version}-rpms"
-        maintenance_repo_id = "rhel-#{rh_version_major}-server-satellite-maintenance-6-rpms"
+        repos_arrary = common_repos_array(rh_version_major, full_version)
+        return repos_arrary.first(1) if feature(:capsule)
 
-        # Override to use Beta repositories for sat version until GA
-        if ENV['FOREMAN_MAINTAIN_USE_BETA'] == '1'
-          tools_repo_id = "rhel-#{rh_version_major}-server-satellite-tools-6-beta-rpms"
-          maintenance_repo_id = "rhel-#{rh_version_major}-server-satellite-maintenance-6-beta-rpms"
-        end
+        repos_arrary
+      end
 
-        [tools_repo_id, maintenance_repo_id]
+      def common_repos_array(rh_version_major, full_version)
+        ["rhel-#{rh_version_major}-server-satellite-maintenance-6#{use_beta}-rpms",
+         "rhel-#{rh_version_major}-server-satellite-tools-#{full_version}#{use_beta}-rpms"]
+      end
+
+      def use_beta
+        return '-beta' if ENV['FOREMAN_MAINTAIN_USE_BETA'] == '1'
+
+        nil
       end
 
       def main_rh_repos(rh_version_major)


### PR DESCRIPTION
This adds the scenario for Capsule upgrade and below are changes,

1. The performance check is already designed to run on drives for which corresponding directories are available, i.e if pgsql is not available on Capsule skip check for that. The description of check was generic. Its dynamic now to show spinner message for Capsule and Satellite.
2. The original asset check was not guarded to run on system which has foreman package installed, it has changed to avoid running it on Capsule.
3. The downstream concern now handles satellite-tools repo conditionally for Satellite and Capsule.
4. This PR changes the way to register scenarios for upgrade. New changes only allow either Satellite or Capsule scenarios to be registered for upgrade. The scenario registration logic is in one file instead of having it in every scenario file.